### PR TITLE
Th quiz+end+style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,7 +6,7 @@
     --accent2a: #316997;
     --homepagepurple: #B83BCE;
     --errorred: #ea5656;
-    --correctgreen: #8fc254;
+    --correctgreen: #55bd51;
     --font: #efefef;
     --curvedcorner1: 20px;
     --curvedcorner2: 10px;
@@ -186,6 +186,7 @@ body#endpage {
 
 .quiz-tablet {
     max-width: 1000px;
+    width: 94%;
     background-color: #aaa;
     border-radius: var(--curvedcorner1);
     box-shadow: 6px 8px 21px 0px rgba(0, 0, 0, 1);
@@ -235,9 +236,39 @@ body#endpage {
     transform: translateY(4px);
 }
 
+.select-incorrect {
+    background-color: var(--errorred);
+}
+
+.select-correct {
+    background-color: var(--correctgreen);
+}
+
+.quiz-modal,
+.quiz-modal h1,
+.quiz-modal p {
+    color: #090909;
+}
+
 /*end page*/
+.score {
+    background-color: var(--accent2);
+}
 
+/*side column*/
+.side-widget {
+    border-radius: var(--curvedcorner2);
+    background-color: #000;
+}
 
+.side-widget h5 {
+    font-weight: bold;
+}
+
+/*progress bar*/
+#progress-bar { /*remove this style - just to see where it is*/
+    background-color:#999;
+}
 
 /*buttons*/
 

--- a/css/style.css
+++ b/css/style.css
@@ -4,7 +4,7 @@
     --accent1a: #52277c;
     --accent2: #5597cc;
     --accent2a: #316997;
-    /*#2f8ad5*/
+    --homepagepurple: #B83BCE;
     --errorred: #ea5656;
     --correctgreen: #8fc254;
     --font: #efefef;
@@ -15,7 +15,6 @@
 /*page styles*/
 body {
     background-color: #090909;
-    background-image: url("../images/star-bg.jpg");
     background-attachment: fixed;
     color: var(--font);
     font-size: 1.1rem;
@@ -29,58 +28,66 @@ body#homepage {
     background-repeat: no-repeat;
 }
 
-/*quiz tablet*/
-.quiz-tablet {
-    max-width: 1000px;
-    background-color: #aaa;
-    border-radius: var(--curvedcorner1);
-    -webkit-box-shadow: 6px 8px 21px 0px rgba(0, 0, 0, 1);
-    -moz-box-shadow: 6px 8px 21px 0px rgba(0, 0, 0, 1);
-    box-shadow: 6px 8px 21px 0px rgba(0, 0, 0, 1);
+body#quizpage,
+body#endpage {
+    background-image: url("../images/star-bg.jpg");
 }
 
-.tablet-box {
-    border-radius: var(--curvedcorner1);
-    -webkit-box-shadow: 3px 4px 21px -10px rgba(0, 0, 0, 0.75);
-    -moz-box-shadow: 3px 4px 21px -10px rgba(0, 0, 0, 0.75);
-    box-shadow: 3px 4px 21px -10px rgba(0, 0, 0, 0.75);
-    background-color: var(--accent2);
-    border: 1px solid var(--accent2a);
+/* navigation bar */
+.navbar {
+    margin-bottom: 0;
+    border-bottom: none;
 }
 
-.tablet-box-alt {
-    background-color: var(--accent1);
-    border: 1px solid var(--accent1a);
+.navbar-brand {
+    font-size: 30px;
+    margin-left: 15px;
+    color: var(--accent1); /*need to choose a purple*/
+    color: #d95fee;
+    /* Adjusting the font size of the brand/logo */
 }
 
-.question,
-.answer {
-    font-size: 1.5em;
+.navbar-toggler-icon {
+    color: #ffffff5a !important;
+
 }
 
-.image-container img {
-    border-radius: 20px;
-    max-height: 400px;
-    border: 3px solid var(--accent1a);
+.nav-link {
+    color: #fffffff1 !important;
+    margin-right: 40px;
+    background-color: var(--homepagepurple);
+    font-weight: bold;
+
 }
 
-.answer {
-    cursor: pointer;
+.nav-link:hover {
+    color: var(--accent1) !important; /*need to choose a purple*/
+    color: var(--homepagepurple) !important;
+    background-color: rgb(251, 250, 250);
+    transition: color 0.3s, background-color 0.3s;
 }
 
-/*buttons*/
-
-#btn-startquiz {
-    font-size: 2em !important;
-    background-color: #B83BCE !important;
-    border-color: #B83BCE;
-    margin-top: 3rem;
-    margin-bottom: 1rem;
+.navbar-dark.bg-dark {
+    background-color: #00000032 !important;
+    /* Background color of the navbar */
 }
 
-/* Header editing */
+.navbar-nav {
+    padding-left: 30rem !important;
+}
 
-h1 {
+.navbar-brand img {
+    margin-right: 10px;
+}
+
+.dropdown-menu-right .dropdown-item:hover {
+    background-color: var(--homepagepurple) !important;
+    color: white !important;
+}
+
+/* Home page */
+
+#homepage h1 {
     font-size: 4rem;
     background-color: rgba(0, 0, 0, 0.279);
     color: white;
@@ -89,7 +96,8 @@ h1 {
 
 }
 
-.intro-text p {
+.intro-text p,
+.star-wars p {
     background-color: rgba(0, 0, 0, 0.427);
     color: white;
     justify-content: center;
@@ -173,66 +181,70 @@ h1 {
     color: #feda4a;
 }
 
-/* Custom CSS for the navigation bar */
-.navbar {
-    margin-bottom: 0;
-    border-bottom: none;
+
+/*quiz page*/
+
+.quiz-tablet {
+    max-width: 1000px;
+    background-color: #aaa;
+    border-radius: var(--curvedcorner1);
+    box-shadow: 6px 8px 21px 0px rgba(0, 0, 0, 1);
 }
 
-.navbar-brand {
-    font-size: 30px;
-    margin-left: 15px;
-    color: #d95fee;
-    /* Adjusting the font size of the brand/logo */
+.tablet-box {
+    border-radius: var(--curvedcorner1);
+    box-shadow: 3px 4px 21px -10px rgba(0, 0, 0, 0.5);
+    background-color: var(--accent2);
+    border: 1px solid var(--accent2a);
 }
 
-.navbar-toggler-icon {
-    color: #ffffff5a !important;
-
+.tablet-box-alt {
+    background-color: var(--accent1);
+    border: 1px solid var(--accent1a);
 }
 
-.nav-link {
-    color: #fffffff1 !important;
-    margin-right: 40px;
-    background-color: #B83BCE;
-    font-weight: bold;
-
+.question,
+.answer {
+    font-size: 1.4rem;
 }
 
-.nav-link:hover {
-    color: #B83BCE !important;
-    background-color: rgb(251, 250, 250);
-    transition: color 0.3s, background-color 0.3s;
-}
-
-.navbar-dark.bg-dark {
-    background-color: #00000032 !important;
-    /* Background color of the navbar */
-}
-
-.navbar-nav {
-    padding-left: 30rem !important;
-}
-
-.navbar-brand img {
-    margin-right: 10px;
-}
-
-.dropdown-menu-right .dropdown-item:hover {
-    background-color: #B83BCE !important;
-    color: white !important;
-}
-
-#question-image {
-    text-align: center;
-    /* Center-align the images within the div */
-}
-
-#question-image img {
+.image-container img {
+    border-radius: var(--curvedcorner1);
+    max-height: 550px;
     max-width: 100%;
-    /* Setting the maximum width of the image to 100% of its container */
-    height: auto;
-    /* Allowing the image's height to adjust proportionally based on its width */
-    margin-top: 10px;
-    /* Adding some top margin to separate the image from the question */
+    border: 5px solid var(--accent2a);
+}
+
+.question {
+    border-width: 3px;
+}
+
+.answer {
+    cursor: pointer;
+    border: none;
+    box-shadow: 0 8px var(--accent1a);
+}
+
+.answer:hover,
+.answer:focus {
+    opacity: 0.90;
+}
+
+.answer:active {
+    box-shadow: 0 4px var(--accent1a);
+    transform: translateY(4px);
+}
+
+/*end page*/
+
+
+
+/*buttons*/
+
+#btn-startquiz {
+    font-size: 2em !important;
+    background-color: var(--homepagepurple) !important;
+    border-color: var(--homepagepurple);
+    margin-top: 3rem;
+    margin-bottom: 1rem;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -2,17 +2,23 @@
 :root {
     --accent1: #a667e5;
     --accent1a: #52277c;
-    --accent2: #ea5656;
-    --accent2a: #8b3428;
+    --accent2: #5597cc;
+    --accent2a: #316997;
+    /*#2f8ad5*/
+    --errorred: #ea5656;
+    --correctgreen: #8fc254;
     --font: #efefef;
+    --curvedcorner1: 20px;
+    --curvedcorner2: 10px;
 }
 
 /*page styles*/
-body#quizpage {
+body {
     background-color: #090909;
     background-image: url("../images/star-bg.jpg");
     background-attachment: fixed;
     color: var(--font);
+    font-size: 1.1rem;
 }
 
 body#homepage {
@@ -21,40 +27,35 @@ body#homepage {
     background-size: cover;
     /* This ensures the entire image covers the viewport */
     background-repeat: no-repeat;
-    background-attachment: fixed;
-}
-
-body#quizend {
-    background-color: #090909;
-    background-image: url("../images/star-bg.jpg");
-    background-attachment: fixed;
-    color: var(--font);
 }
 
 /*quiz tablet*/
 .quiz-tablet {
     max-width: 1000px;
     background-color: #aaa;
-    border-radius: 20px;
+    border-radius: var(--curvedcorner1);
     -webkit-box-shadow: 6px 8px 21px 0px rgba(0, 0, 0, 1);
     -moz-box-shadow: 6px 8px 21px 0px rgba(0, 0, 0, 1);
     box-shadow: 6px 8px 21px 0px rgba(0, 0, 0, 1);
 }
 
-.question,
-.answer {
-    background-color: var(--accent1);
-    border: 1px solid var(--accent1a);
-    border-radius: 20px;
+.tablet-box {
+    border-radius: var(--curvedcorner1);
     -webkit-box-shadow: 3px 4px 21px -10px rgba(0, 0, 0, 0.75);
     -moz-box-shadow: 3px 4px 21px -10px rgba(0, 0, 0, 0.75);
     box-shadow: 3px 4px 21px -10px rgba(0, 0, 0, 0.75);
-    font-size: 1.5em;
-}
-
-.question {
     background-color: var(--accent2);
     border: 1px solid var(--accent2a);
+}
+
+.tablet-box-alt {
+    background-color: var(--accent1);
+    border: 1px solid var(--accent1a);
+}
+
+.question,
+.answer {
+    font-size: 1.5em;
 }
 
 .image-container img {
@@ -78,6 +79,7 @@ body#quizend {
 }
 
 /* Header editing */
+
 h1 {
     font-size: 4rem;
     background-color: rgba(0, 0, 0, 0.279);
@@ -87,7 +89,7 @@ h1 {
 
 }
 
-p {
+.intro-text p {
     background-color: rgba(0, 0, 0, 0.427);
     color: white;
     justify-content: center;

--- a/css/style.css
+++ b/css/style.css
@@ -245,9 +245,18 @@ body#endpage {
 }
 
 .quiz-modal,
-.quiz-modal h1,
+.quiz-modal h3, .quiz-modal h4,
 .quiz-modal p {
     color: #090909;
+}
+
+.quiz-modal h3 {
+    font-weight: bold;
+}
+
+.quiz-modal h4 {
+    font-size: 1.2rem;
+    text-decoration: underline;
 }
 
 /*end page*/

--- a/css/style.css
+++ b/css/style.css
@@ -281,10 +281,35 @@ body#endpage {
 
 /*buttons*/
 
+#btn-returnhome {
+    background-color: var(--accent1a);
+    border-color: var(--accent1a);
+    font-size: 1.6rem;
+    font-weight: bold;
+}
+
+#btn-returnhome:hover {
+    opacity: 0.8;
+}
+
 #btn-startquiz {
     font-size: 2em !important;
     background-color: var(--homepagepurple) !important;
     border-color: var(--homepagepurple);
     margin-top: 3rem;
     margin-bottom: 1rem;
+}
+
+.btn-howtoplay {
+    border-radius: var(--curvedcorner1) !important;
+    background-color: var(--accent1a) !important;
+    border-color: var(--accent1a) !important;
+    color: #fff !important;
+    font-weight: bold;
+    padding: 3px 13px;
+    font-size: 1.2rem;
+}
+
+.btn-howtoplay:hover {
+    opacity: 0.8;
 }

--- a/end.html
+++ b/end.html
@@ -7,23 +7,11 @@
     <title>Thank you for playing AstroQuiz!</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link href="./css/style.css" rel="stylesheet" type="text/css">
+    <link href="css/style.css" rel="stylesheet" type="text/css">
 </head>
 <!--move these into style.css, merge with existing box styles-->
 <style>
-    .tablet-box {
-        border-radius: 20px;
-        -webkit-box-shadow: 3px 4px 21px -10px rgba(0, 0, 0, 0.75);
-        -moz-box-shadow: 3px 4px 21px -10px rgba(0, 0, 0, 0.75);
-        box-shadow: 3px 4px 21px -10px rgba(0, 0, 0, 0.75);
-        background-color: var(--accent2);
-        border: 1px solid var(--accent2a);
-    }
 
-    .tablet-box-alt {
-        background-color: var(--accent1);
-        border: 1px solid var(--accent1a);
-    }
 </style>
 
 <body id="quizend"> <!-- for body change -->
@@ -92,7 +80,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
         crossorigin="anonymous"></script>
-    <script src="/js/script.js"></script>
+    <script src="js/script.js"></script>
 </body>
 
 </html>

--- a/end.html
+++ b/end.html
@@ -9,12 +9,8 @@
         integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link href="css/style.css" rel="stylesheet" type="text/css">
 </head>
-<!--move these into style.css, merge with existing box styles-->
-<style>
 
-</style>
-
-<body id="quizend"> <!-- for body change -->
+<body id="quizend">
     <header class="container">
         <div class="row">
             <div class="col">
@@ -22,52 +18,47 @@
             </div>
         </div>
     </header>
-    <main class="container-md px-4 quiz-tablet mt-5 p-4">
-        <div class="endgame show">
-            <div class="row">
-                <section class="page-header tablet-box col text-center p-5 mb-3">
-                    <h1>Game Over</h1>
-                </section>
-            </div>
-            <div class="row">
-                <section id="score-box" class="col tablet-box text-center p-4 mt-3 mb-3">
-                    <p>You scored <span class="score">SCORE GOES HERE</span>!</p>
-                    <p>Enter your initials to save your high score</p>
-                    <input type="text" class="yourname" />
-                    <button id="submit-score">Submit</button>
-                </section>
-            </div>
-            <div class="row">
-                <section id="button-holder" class="col button-holder tablet-box text-center p-5">
-                    <a id="btn-returnhome" class="btn btn-primary px-5 py-3 mt-3" href="index.html">Return to Base</a>
-                </section>
-            </div>
-        </div>
-        <div class="leaderboard show">
-            <div class="row">
-                <section class="page-header tablet-box col text-center p-5 mb-3">
-                    <h1>Leaderboard</h1>
-                </section>
-            </div>
-            <div class="row">
-                <section id="high-scores" class="col tablet-box text-center p-4 mt-3 mb-3">
-                    <div class="score tablet-box tablet-box-alt mx-5 my-2 p-2">Score 1</div>
-                    <div class="score tablet-box tablet-box-alt mx-5 my-2 p-2">Score 2</div>
-                    <div class="score tablet-box tablet-box-alt mx-5 my-2 p-2">Score 3</div>
-                    <div class="score tablet-box tablet-box-alt mx-5 my-2 p-2">Score 4</div>
-                    <div class="score tablet-box tablet-box-alt mx-5 my-2 p-2">Score 5</div>
-                    <div class="score tablet-box tablet-box-alt mx-5 my-2 p-2">Score 6</div>
-                    <div class="score tablet-box tablet-box-alt mx-5 my-2 p-2">Score 7</div>
-                    <div class="score tablet-box tablet-box-alt mx-5 my-2 p-2">Score 8</div>
-                    <div class="score tablet-box tablet-box-alt mx-5 my-2 p-2">Score 9</div>
-                    <div class="score tablet-box tablet-box-alt mx-5 my-2 p-2">Score 9</div>
-                </section>
-            </div>
-            <div class="row">
-                <section id="button-holder" class="col button-holder tablet-box text-center p-5">
-                    <a id="btn-returnhome" class="btn btn-primary px-5 py-3 mt-3" href="index.html">Return to Base</a>
-                </section>
-            </div>
+    <main class="container-md quiz-tablet mt-5 p-4">
+        <div class="row">
+            <section class="col-xs-12 col-sm-10 order-sm-2">
+                <div class="endgame show">
+                    <section class="page-header tablet-box tablet-box-alt col text-center p-5 mb-3">
+                        <h1>Game Over</h1>
+                    </section>
+                    <section id="score-box" class="col tablet-box tablet-box-alt text-center p-4 mt-3 mb-3">
+                        <p>You scored <span class="this-score">SCORE GOES HERE</span>!</p>
+                        <p>Enter your name to save your high score</p>
+                        <input type="text" class="yourname" />
+                        <button id="submit-score" class="btn btn-primary">Save</button>
+                    </section>
+                    <section id="button-holder" class="col button-holder tablet-box tablet-box-alt text-center p-5">
+                        <a id="btn-returnhome" class="btn btn-primary px-5 py-3 mt-3" href="index.html">Return to Base</a>
+                    </section>
+                </div>
+                <div class="leaderboard show">
+                    <section class="page-header tablet-box tablet-box-alt col text-center p-5 mb-3">
+                        <h1>Leaderboard</h1>
+                    </section>
+                    <section id="high-scores" class="col tablet-box tablet-box-alt text-center p-4 mt-3 mb-3">
+                        <div class="score tablet-box mx-5 my-2 p-2">Score 1</div>
+                        <div class="score tablet-box mx-5 my-2 p-2">Score 2</div>
+                        <div class="score tablet-box mx-5 my-2 p-2">Score 3</div>
+                        <div class="score tablet-box mx-5 my-2 p-2">Score 4</div>
+                        <div class="score tablet-box mx-5 my-2 p-2">Score 5</div>
+                        <div class="score tablet-box mx-5 my-2 p-2">Score 6</div>
+                        <div class="score tablet-box mx-5 my-2 p-2">Score 7</div>
+                        <div class="score tablet-box mx-5 my-2 p-2">Score 8</div>
+                        <div class="score tablet-box mx-5 my-2 p-2">Score 9</div>
+                        <div class="score tablet-box mx-5 my-2 p-2">Score 9</div>
+                    </section>
+                    <section id="button-holder" class="col button-holder tablet-box tablet-box-alt text-center p-5">
+                        <a id="btn-returnhome" class="btn btn-primary px-5 py-3 mt-3" href="index.html">Return to Base</a>
+                    </section>
+                </div>
+            </section>
+            <aside class="col-xs-12 col-sm-2 order-sm-1">
+                side
+            </aside>
         </div>
     </main>
     <footer class="container mt-4">

--- a/js/questions.js
+++ b/js/questions.js
@@ -2,6 +2,7 @@ let questions = [
   {
     title: "Earth:\nWhat is the average diameter of Earth in kilometers?",
     nasaId: "PIA00114",
+    solaireId: "terre",
     choices: [
       "A) Approximately 12,742 kilometers",
       "B) Approximately 6,371 kilometers",
@@ -14,6 +15,7 @@ let questions = [
   {
     title: "Moon:\nWhat is the average temperature on the Moon's surface?",
     nasaId: "PIA00225",
+    solaireId: "lune",
     choices: ["A) -50°C", "B) 20°C", "C) 100°C", "D) -100°C"],
     answer: "D",
     userAnswer: null,
@@ -22,6 +24,7 @@ let questions = [
     title:
       "Mercury:\nWhich feature on Mercury is similar to the Moon's 'seas' but is named differently?",
     nasaId: "GSFC_20171208_Archive_e001545",
+    solaireId: "mercure",
     choices: ["A) Oceans", "B) Lakes", "C) Maria", "D) Plains"],
     answer: "C",
     userAnswer: null,
@@ -30,6 +33,7 @@ let questions = [
     title:
       "Venus:\nWhich of the following gases is most abundant in Venus's atmosphere?",
     nasaId: "GSFC_20171208_Archive_e001734",
+    solaireId: "venus",
     choices: ["A) Oxygen", "B) Nitrogen", "C) Carbon dioxide", "D) Hydrogen"],
     answer: "C",
     userAnswer: null,
@@ -38,6 +42,7 @@ let questions = [
     title:
       "Mars:\nWhich spacecraft successfully landed on Mars in 2021 and began exploring the planet's surface?",
     nasaId: "PIA25658",
+    solaireId: "mars",
     choices: ["A) Voyager 1", "B) Curiosity", "C) Hubble", "D) Rosetta"],
     answer: "B",
     userAnswer: null,
@@ -46,6 +51,7 @@ let questions = [
     title: "Jupiter:\nWhat is the largest moon of Jupiter?",
     nasaId:
       "hubble-captures-vivid-auroras-in-jupiters-atmosphere_28000029525_o",
+    solaireId: "jupiter",
     choices: ["A) Europa", "B) Io", "C) Ganymede", "D) Callisto"],
     answer: "C",
     userAnswer: null,
@@ -54,6 +60,7 @@ let questions = [
     title:
       "Saturn:\nWhat is the name of the largest and most famous ring system around Saturn?",
     nasaId: "PIA04913",
+    solaireId: "saturne",
     choices: [
       "A) The Halo Rings",
       "B) The Belt Rings",
@@ -67,6 +74,7 @@ let questions = [
     title:
       "Uranus:\nWhich unique feature of Uranus sets it apart from most other planets in our solar system?",
     nasaId: "stsci-h-p1906c-f-514x514.a",
+    solaireId: "uranus",
     choices: [
       "A) It has no atmosphere",
       "B) It rotates on its side",
@@ -80,6 +88,7 @@ let questions = [
     title:
       "Neptune:\nWhat is the largest storm system on Neptune, similar to Jupiter's Great Red Spot?",
     nasaId: "PIA02210",
+    solaireId: "neptune",
     choices: [
       "A) Neptune's Cyclone",
       "B) Neptune's Hurricane",
@@ -93,6 +102,7 @@ let questions = [
     title:
       "Pluto:\nWhich spacecraft conducted a close flyby of Pluto in 2015, providing valuable data about the dwarf planet?",
     nasaId: "PIA19952",
+    solaireId: "pluton",
     choices: ["A) Cassini", "B) New Horizons", "C) Voyager 2", "D) Kepler"],
     answer: "B",
     userAnswer: null,

--- a/js/solaire.js
+++ b/js/solaire.js
@@ -1,0 +1,10 @@
+let queryURL = 'https://api.le-systeme-solaire.net/rest/bodies/terre';
+
+fetch(queryURL)
+    .then (function (response) {
+        return response.json();
+    }).then(function (data) {
+        console.log(data);
+        let planetMoons = data.moons.length;
+        console.log(planetMoons);
+ });

--- a/js/solaire.js
+++ b/js/solaire.js
@@ -1,10 +1,50 @@
-let queryURL = 'https://api.le-systeme-solaire.net/rest/bodies/terre';
+//let queryURL = `https://api.le-systeme-solaire.net/rest/bodies/${solaireId}`;
+let queryURL = `https://api.le-systeme-solaire.net/rest/bodies/saturne`;
+let planetName;
+let planetMoons;
+let planetOrbit;
+let modalDYK = document.querySelector(".modal-dyk");
+
+function buildDYK () {
+    let dyk = "";
+
+    if (planetMoons === 0 && planetName != "Moon") {
+        dyk+= `${planetName}`;
+    } else if (planetMoons === 1) {
+        dyk+= `${planetName} has 1 moon and`;
+    } else if (planetMoons > 1) {
+        dyk+=`${planetName} has ${planetMoons} moons and`;
+    }
+
+    dyk+= ` takes ${planetOrbit} days to orbit the sun!`
+    console.log(dyk);
+    modalDYK.textContent = dyk;
+}
 
 fetch(queryURL)
     .then (function (response) {
         return response.json();
     }).then(function (data) {
-        console.log(data);
-        let planetMoons = data.moons.length;
-        console.log(planetMoons);
+        //console.log(data);
+        planetName = data.englishName;
+        //console.log(planetName);
+        planetMoons = data.moons.length;
+        //console.log(planetMoons);
+        planetOrbit = Math.floor(data.sideralOrbit);
+        //console.log(planetOrbit);
+        buildDYK();
  });
+ 
+// need to do some different things for the moon.......
+
+
+//terre
+//lune
+//mercure
+//venus
+//mars
+//jupiter
+//saturne
+//uranus
+//neptune
+//pluton

--- a/quiz.html
+++ b/quiz.html
@@ -21,22 +21,22 @@
     <main class="container-md px-4 quiz-tablet mt-5 p-4">
         <div class="row">
             <section class="col-xs-12 col-sm-10 order-sm-2">
+                <div id="question-image" class="image-container text-center"><!-- div for displaying NASA images --></div> 
                 <div id="question-box" class="question tablet-box mt-3 mb-3 p-4">
-                    Sample question to see layout. Delete when JS is in. What is the weather today?
+                    <!-- Question to be populated here -->
                 </div>
-                <div id="question-image"></div> <!-- This is the new div for displaying NASA images -->
                 <div class="answers">
                     <div id="select-a" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
-                        Donec sodales risus sed diam lacinia aliquet.
+                        <!-- Answer A to be populated here -->
                     </div>
                     <div id="select-b" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
-                        Etiam a dignissim diam.
+                        <!-- Answer B to be populated here -->
                     </div>
                     <div id="select-c" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                        <!-- Answer C to be populated here --> 
                     </div>
                     <div id="select-d" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
-                        Vivamus sed cursus orci.
+                        <!-- Answer D to be populated here -->
                     </div>
                 </div>
             </section>

--- a/quiz.html
+++ b/quiz.html
@@ -10,7 +10,7 @@
     <link href="css/style.css" rel="stylesheet" type="text/css">
 </head>
 
-<body id="quizpage"> <!-- created an id to differentiate the quiz body from homepage -->
+<body id="quizpage">
     <header class="container">
         <div class="row">
             <div class="col">
@@ -18,7 +18,7 @@
             </div>
         </div>
     </header>
-    <main class="container-md px-4 quiz-tablet mt-5 p-4">
+    <main class="container-md quiz-tablet mt-5 p-4">
         <div class="row">
             <section class="col-xs-12 col-sm-10 order-sm-2">
                 <div id="question-image" class="image-container text-center"><!-- div for displaying NASA images --></div> 
@@ -26,25 +26,40 @@
                     <!-- Question to be populated here -->
                 </div>
                 <div class="answers">
-                    <div id="select-a" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
+                    <div id="select-a" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4" data-clicked="unclicked">
                         <!-- Answer A to be populated here -->
                     </div>
-                    <div id="select-b" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
+                    <div id="select-b" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4" data-clicked="unclicked">
                         <!-- Answer B to be populated here -->
                     </div>
-                    <div id="select-c" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
+                    <div id="select-c" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4" data-clicked="unclicked">
                         <!-- Answer C to be populated here --> 
                     </div>
-                    <div id="select-d" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
+                    <div id="select-d" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4" data-clicked="unclicked">
                         <!-- Answer D to be populated here -->
                     </div>
                 </div>
             </section>
             <aside class="col-xs-12 col-sm-2 order-sm-1">
+                <div class="side-widget text-center my-2 p-3">
+                    <h5>Points Available</h5>
+                    <p class="points-available">100</p>
+                </div>
+                <div class="side-widget text-center my-2 p-3">
+                    <h5>Your Score So Far</h5>
+                    <p class="current-score">100</p>
+                </div>
+                <div id="progress-bar" class="text-center">
+                    Progress bar goes here
+                </div>
                 <!--these probably want different styling and positions but are here for functionality for now-->
                 <button id="btn-more-info" class="btn btn-primary" disabled>Learn More</button>
                 <button id="btn-abort" class="btn btn-danger"><a href="index.html">Abort Mission</a></button>
-                <button id="next-question" class="btn btn-success">Next Question</button>
+                <button id="next-questions" class="btn btn-success">Next Question</button>
+                <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#correctModal">
+                    Correct
+                  </button>
+                  
             </aside>
         </div>
     </main>
@@ -55,8 +70,25 @@
             </div>
         </div>
     </footer>
-
+    <!-- Modal -->
+    <div class="modal fade quiz-modal" id="correctModal" tabindex="-1" aria-labelledby="correctModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                <h1 class="modal-title fs-5" id="correctModalLabel">Correct!</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    That's the correct answer!
+                </div>
+                <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button id="next-question" type="button" class="btn btn-success">Next Question</button>
+                </div>
+            </div>
+        </div>
     </div>
+  
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
         crossorigin="anonymous"></script>
@@ -64,5 +96,4 @@
     <script src="js/questions.js"></script>
     <script src="js/script.js"></script>
 </body>
-
 </html>

--- a/quiz.html
+++ b/quiz.html
@@ -49,13 +49,17 @@
                     <h5>Your Score So Far</h5>
                     <p class="current-score">100</p>
                 </div>
+                <div class="text-center my-2">
+                    <button type="button" class="btn btn-primary btn-howtoplay" data-bs-toggle="modal" data-bs-target="#howModal">?</button>
+                </div>
                 <div id="progress-bar" class="text-center">
                     Progress bar goes here
                 </div>
-                <!--these probably want different styling and positions but are here for functionality for now-->
-                <p>Buttons to remove</p>
-                <button id="btn-abort" class="btn btn-danger"><a href="index.html">Abort Mission</a></button>
-                <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#correctModal">Correct Modal</button>
+                <div>
+                    <p>Buttons to remove</p>
+                    <button id="btn-abort" class="btn btn-danger"><a href="index.html">Abort Mission</a></button>
+                    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#correctModal">Correct Modal</button>
+                </div>
             </aside>
         </div>
     </main>
@@ -66,7 +70,7 @@
             </div>
         </div>
     </footer>
-    <!-- Modal -->
+    <!-- Modals -->
     <div class="modal fade quiz-modal" id="correctModal" tabindex="-1" aria-labelledby="correctModalLabel" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -81,6 +85,22 @@
                 <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
                 <button id="next-question" type="button" class="btn btn-success">Next Question</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="modal fade quiz-modal" id="howModal" tabindex="-1" aria-labelledby="howModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                <h3 class="modal-title fs-5" id="howModalLabel">How to Play!</h3>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Choose the correct answer from the options to power up your ship! But be careful! You will lose 25 points for each incorrect answer!</p>
+                </div>
+                <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
                 </div>
             </div>
         </div>

--- a/quiz.html
+++ b/quiz.html
@@ -53,13 +53,9 @@
                     Progress bar goes here
                 </div>
                 <!--these probably want different styling and positions but are here for functionality for now-->
-                <button id="btn-more-info" class="btn btn-primary" disabled>Learn More</button>
+                <p>Buttons to remove</p>
                 <button id="btn-abort" class="btn btn-danger"><a href="index.html">Abort Mission</a></button>
-                <button id="next-questions" class="btn btn-success">Next Question</button>
-                <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#correctModal">
-                    Correct
-                  </button>
-                  
+                <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#correctModal">Correct Modal</button>
             </aside>
         </div>
     </main>
@@ -75,11 +71,12 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                <h1 class="modal-title fs-5" id="correctModalLabel">Correct!</h1>
+                <h3 class="modal-title fs-5" id="correctModalLabel">Correct!</h3>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    That's the correct answer!
+                    <h4 class="modal-dyk-subheading">Did you know?</h4>
+                    <p class="modal-dyk"></p>
                 </div>
                 <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>

--- a/quiz.html
+++ b/quiz.html
@@ -7,7 +7,7 @@
     <title>AstroQuiz</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link href="./css/style.css" rel="stylesheet" type="text/css">
+    <link href="css/style.css" rel="stylesheet" type="text/css">
 </head>
 
 <body id="quizpage"> <!-- created an id to differentiate the quiz body from homepage -->
@@ -26,16 +26,16 @@
                 </div>
                 <div id="question-image"></div> <!-- This is the new div for displaying NASA images -->
                 <div class="answers">
-                    <div id="select-a" class="clickable answer mt-3 mb-3 p-4">
+                    <div id="select-a" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
                         Donec sodales risus sed diam lacinia aliquet.
                     </div>
-                    <div id="select-b" class="clickable answer mt-3 mb-3 p-4">
+                    <div id="select-b" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
                         Etiam a dignissim diam.
                     </div>
-                    <div id="select-c" class="clickable answer mt-3 mb-3 p-4">
+                    <div id="select-c" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                     </div>
-                    <div id="select-d" class="clickable answer mt-3 mb-3 p-4">
+                    <div id="select-d" class="clickable answer tablet-box tablet-box-alt mt-3 mb-3 p-4">
                         Vivamus sed cursus orci.
                     </div>
                 </div>

--- a/quiz.html
+++ b/quiz.html
@@ -95,5 +95,6 @@
 
     <script src="js/questions.js"></script>
     <script src="js/script.js"></script>
+    <script src="js/solaire.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- created css variables for repeated colours
- created overall body style selector for DNR
- added homepage selector to h1 and p styles for homepage so they don't impact the other pages
- changed colour scheme
- refactored some css classes
- removed dummy text for question and answers
- removed legacy box shadow styles
- put question image back at the top of the page
- removed text-align: center from image div and added bootstrap text-center class
- removed #question-image img styles. margin-top not required now the image is at the top again. height auto has been reduced to 550 px to reduce scrolling before you see the question, max width moved to existing image-container selector
- added border and curved corners back to image
- added data-clicked attribute we may want to use instead of selecting 'red' bgcolor in js
- removed general star bg from home page as this looks a bit odd when while waiting for nasa image to load
- added width 94% to quiz-tablet so it doesn't go up to the edge on mobile devices
- added size column to end page
- added classes select-incorrect and select-correct which can be used to set/reset question colours in js
- got rid of unnecessary bootstrap divs on end page
- added push button effect on quiz buttons
- added modals for correct answer and how to play
- found solar system api with info on planets and moons - pulled sample info on we can use in a popup instead of wikipedia. 
- edited questions.js to add property for systeme solaire api